### PR TITLE
Add missing `file` dependency for RockyLinux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,3 +35,4 @@
 ### Fixes
 
 * Fix centos 8 dockerfile
+* Add missing `file` dependency for RockyLinux

--- a/dockerfiles/rockylinux-latest/Dockerfile
+++ b/dockerfiles/rockylinux-latest/Dockerfile
@@ -7,5 +7,6 @@ RUN bundle config set without 'development' && \
 RUN bundle config set without 'development' && \
     bundle install
 RUN dnf -y install https://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm
-RUN dnf -y install onlyoffice-documentbuilder
+RUN dnf -y install file \
+                   onlyoffice-documentbuilder
 CMD rake rspec_critical


### PR DESCRIPTION
This is optional dep for `ooxml_parser`
Everything works without it for un-passworeded files, but logs is spammed with:

```
sh: line 1: file: command not found
```

See:
https://github.com/ONLYOFFICE/doc-builder-testing/actions/runs/10004599714/job/27654344390?pr=1161