### PR TITLE
Fix rake task for modified spec

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,14 +26,12 @@ jobs:
   run_modified_files_in_default_docker:
     runs-on: ubuntu-latest
     steps:
-      # pull current branch
+      # Pull current branch
       - name: Checkout HEAD
         uses: actions/checkout@v4
-      # pull master to run git diff command
-      - name: Checkout master
-        uses: actions/checkout@v4
-        with:
-          ref: master
+      # Fetch master branch to run git diff command
+      - name: Fetch master branch
+        run: git fetch origin master
       - name: Running test inside doc-builder-testing
         run: |
           docker build -t doc-builder-testing .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,8 +26,10 @@ jobs:
   run_modified_files_in_default_docker:
     runs-on: ubuntu-latest
     steps:
+      # pull current branch
       - name: Checkout HEAD
         uses: actions/checkout@v4
+      # pull master to run git diff command
       - name: Checkout master
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,12 +26,12 @@ jobs:
   run_modified_files_in_default_docker:
     runs-on: ubuntu-latest
     steps:
-      # Pull current branch
       - name: Checkout HEAD
         uses: actions/checkout@v4
-      # Fetch master branch to run git diff command
+        with:
+          fetch-depth: 0  # Fetch the full history to access other branches
       - name: Fetch master branch
-        run: git fetch origin master
+        run: git fetch origin master  # Fetch the master branch
       - name: Running test inside doc-builder-testing
         run: |
           docker build -t doc-builder-testing .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,12 @@ jobs:
   run_modified_files_in_default_docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout HEAD
+        uses: actions/checkout@v4
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
       - name: Running test inside doc-builder-testing
         run: |
           docker build -t doc-builder-testing .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout HEAD
         uses: actions/checkout@v4
-#      - name: Checkout master
-#        uses: actions/checkout@v4
-#        with:
-#          ref: master
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
       - name: Running test inside doc-builder-testing
         run: |
           docker build -t doc-builder-testing .

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout HEAD
         uses: actions/checkout@v4
-      - name: Checkout master
-        uses: actions/checkout@v4
-        with:
-          ref: master
+#      - name: Checkout master
+#        uses: actions/checkout@v4
+#        with:
+#          ref: master
       - name: Running test inside doc-builder-testing
         run: |
           docker build -t doc-builder-testing .

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ task :in_modified_specs do
   run_default = false
 
   # get changes in framework
-  lib_diff = `git diff --name-only origin/master -- lib dockerfiles Dockerfile Gemfile Gemfile.lock`
+  lib_diff = `git diff --name-only origin/master -- lib dockerfiles Dockerfile Gemfile Gemfile.lock 2>&1`
   run_default = true if !lib_diff.empty? || lib_diff.include?('fatal:')
 
   # get changes in scripts and find them in spec

--- a/Rakefile
+++ b/Rakefile
@@ -37,7 +37,7 @@ task :in_modified_specs do
 
   # get changes in framework
   lib_diff = `git diff --name-only origin/master -- lib dockerfiles Dockerfile Gemfile Gemfile.lock`
-  run_default = true unless lib_diff.empty?
+  run_default = true if !lib_diff.empty? || lib_diff.include?('fatal:')
 
   # get changes in scripts and find them in spec
   scripts_diff = `git diff --name-only origin/master -- js python | xargs -I {} grep -Rl {} spec`

--- a/Rakefile
+++ b/Rakefile
@@ -45,11 +45,13 @@ task :in_modified_specs do
   spec_diff = `git diff --name-only origin/master -- spec ':!spec/spec_helper.rb' ':!spec/test_data.rb'`
   files = spec_diff.split | scripts_diff.split
 
-  if files.all? { |element| element =~ %r{^spec/.*\.rb} }
-    files.empty? ? print('NO TESTS TO RUN.') : sh("bundle exec parallel_rspec #{files.join(' ')}")
-  else
-    print("An incorrect file type for rspec has been detected: #{files}")
-    run_default = true
+  unless run_default
+    if files.all? { |element| element =~ %r{^spec/.*\.rb} }
+      files.empty? ? print('NO TESTS TO RUN.') : sh("bundle exec parallel_rspec #{files.join(' ')}")
+    else
+      print("An incorrect file type for rspec has been detected: #{files}")
+      run_default = true
+    end
   end
 
   Rake::Task['default'].invoke if run_default

--- a/Rakefile
+++ b/Rakefile
@@ -37,6 +37,7 @@ task :in_modified_specs do
 
   # get changes in framework
   lib_diff = `git diff --name-only origin/master -- lib dockerfiles Dockerfile Gemfile Gemfile.lock 2>&1`
+  # check of comparison results/errors
   run_default = true if !lib_diff.empty? || lib_diff.include?('fatal:')
 
   # get changes in scripts and find them in spec


### PR DESCRIPTION
An error `fatal: bad revision 'origin/master'` was detected when running `git diff` command in the GitHub Actions environment, because by default only the current branch is pulled into the container. To resolve this error, a step `git fetch origin master` was added in the workflow to forcefully pull the master branch changes.